### PR TITLE
Made Course Leaderboard accessible from homepage

### DIFF
--- a/src/app/course/_test/leader-board/leader-board.component.spec.ts
+++ b/src/app/course/_test/leader-board/leader-board.component.spec.ts
@@ -2,8 +2,11 @@ import {ComponentFixture, TestBed} from '@angular/core/testing'
 
 import {LeaderBoardComponent} from '../../leader-board/leader-board.component'
 import {TestModule} from '@test/test.module'
-import {MOCK_COURSE2} from "@app/course/_test/mock"
+import {MOCK_RANKED_LEADERBOARD} from "@app/course/_test/mock"
 import {TuiFilterPipeModule} from "@taiga-ui/cdk"
+import {CourseService} from "@app/course/_services/course.service"
+import {CourseServiceMock} from "@test/course.service.mock"
+import {ActivatedRoute} from "@angular/router"
 
 describe('LeaderBoardComponent', () => {
     let component: LeaderBoardComponent
@@ -12,15 +15,32 @@ describe('LeaderBoardComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [TestModule, TuiFilterPipeModule],
-            declarations: [LeaderBoardComponent]
+            declarations: [LeaderBoardComponent],
+            providers: [
+                {provide: CourseService, useClass: CourseServiceMock},
+                {
+                    provide: ActivatedRoute, useValue: {
+                        snapshot: {
+                            parent: {
+                                params: {
+                                    courseId: 0
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
         }).compileComponents()
     })
 
     beforeEach(() => {
         fixture = TestBed.createComponent(LeaderBoardComponent)
         component = fixture.componentInstance
-        component.leaderBoard = MOCK_COURSE2.leader_board
         fixture.detectChanges()
+    })
+
+    it('course leaderbaord should be retrieved and ranked on initial load', () => {
+        expect(component.leaderBoard).toEqual(MOCK_RANKED_LEADERBOARD)
     })
 
     it('should create', () => {

--- a/src/app/course/_test/mock.ts
+++ b/src/app/course/_test/mock.ts
@@ -3,6 +3,7 @@ import {
     CourseRegistration,
     CourseRegistrationMode,
     EventType,
+    LeaderboardElement,
     Question,
     STATUS,
     TokenUseOption,
@@ -79,7 +80,13 @@ export const MOCK_COURSE1: Course = {
     question_set: null,
     uqjs: null,
     course_reg: MOCK_COURSE_REGISTRATION,
-    leader_board: null,
+    leader_board: [{
+        name: 'name',
+        token: 2,
+    }, {
+        name: 'name 2',
+        token: 5,
+    }],
     has_create_event_permission: true,
     description: "",
     registration_mode: CourseRegistrationMode.OPEN,
@@ -406,3 +413,16 @@ export const MOCK_GOAL_2: Goal = {
 }
 
 export const MOCK_GOALS: Goal[] = [MOCK_GOAL, MOCK_GOAL_2]
+
+export const MOCK_RANKED_LEADERBOARD: LeaderboardElement[] = [
+    {
+        rank: 1,
+        name: 'name 2',
+        token: 5,
+    },
+    {
+        rank: 2,
+        name: 'name',
+        token: 2,
+    }
+]

--- a/src/app/course/course-homepage/course-homepage.component.html
+++ b/src/app/course/course-homepage/course-homepage.component.html
@@ -92,9 +92,8 @@
     <tui-island class="course-tile" size="m">
         <div class="course-background leaderboard"></div>
         <div class="course-tile-text">
-            <h3 class="tui-island__title">Leaderboard
-                and Statistics</h3>
-            <p class="tui-island__paragraph tui-text_body-xl flex-space">View detailed performance statistics.</p>
+            <h3 class="tui-island__title">Leaderboard</h3>
+            <p class="tui-island__paragraph tui-text_body-xl flex-space">View the class leaderboard.</p>
             <div class="course-view-button tui-space_top-3">
                 <span
                     tuiHintPointer
@@ -103,7 +102,7 @@
                 >
                     <a
                         appearance="primary"
-                        [routerLink]="['/stats']"
+                        [routerLink]="['leaderboard']"
                         class="tui-form__button"
                         size="m"
                         tuiButton

--- a/src/app/course/course-routing.module.ts
+++ b/src/app/course/course-routing.module.ts
@@ -19,6 +19,7 @@ import {CourseChallengeSnippetComponent} from "@app/course/course-challenge-snip
 import {CourseHomepageComponent} from "@app/course/course-homepage/course-homepage.component"
 import {CourseEventsSnippetComponent} from "@app/course/course-events-snippet/course-events-snippet.component"
 import {EventStatsComponent} from "@app/course/event/event-stats/event-stats.component"
+import {LeaderBoardComponent} from "@app/course/leader-board/leader-board.component"
 
 
 const routes: Routes = [
@@ -104,6 +105,10 @@ const routes: Routes = [
             {
                 path: 'challenges',
                 component: CourseChallengeSnippetComponent,
+            },
+            {
+                path: 'leaderboard',
+                component: LeaderBoardComponent
             }]
     }]
 

--- a/src/app/course/leader-board/leader-board.component.html
+++ b/src/app/course/leader-board/leader-board.component.html
@@ -1,58 +1,226 @@
-<div *ngIf="leaderBoard" class="tui-container tui-container_adaptive">
-    <div class="top-x-islands tui-space_bottom-8">
-        <tui-island *ngFor="let element of leaderBoard | tuiFilter: filterInTopX: rankTopX; let index = index"
-                    [style.marginTop]="(index) + 'rem'" [style.order]="(index % 2 * -index)"
-                    class="top-x-island"
-                    textAlign="center">
-            <div [style.backgroundColor]="avatar.bgColor" class="top-x-background"></div>
-            <figure class="tui-island__figure">
-                <tui-avatar
-                    #avatar
-                    [autoColor]="true"
-                    [rounded]="true"
-                    [text]="element.name || 'Anonymous User'"
-                    class="top-x-avatar"
-                    size="l"
-                ></tui-avatar>
-            </figure>
-            <p class="tui-island__paragraph tui-text_h3 tui-space_bottom-2">{{ getGetOrdinal(element.rank) }}</p>
-            <h3 class="tui-island__title">
-                {{ element.name || 'Anonymous User' }}
-            </h3>
-            <p class="tui-island__paragraph">
-                {{ element.token ? (element.token + ' Tokens') : 'No Tokens' }}
-            </p>
-        </tui-island>
-    </div>
-    <table [columns]="displayedColumns" class="table" tuiTable>
-        <thead tuiThead>
-        <tr tuiThGroup>
-            <th *tuiHead="'rank'" tuiTh>Rank</th>
-            <th *tuiHead="'name'" tuiTh>Name</th>
-            <th *tuiHead="'token'" tuiTh>Tokens</th>
-        </tr>
-        </thead>
-        <tbody [data]="leaderBoard | tuiFilter: filterOutTopX: rankTopX" tuiTbody>
-        <tr *tuiRow="let element of leaderBoard" tuiTr>
-            <td *tuiCell="'rank'" tuiTd>
-                {{ getGetOrdinal(element.rank) }}
-            </td>
-            <td *tuiCell="'name'" tuiTd>
-                <div class="table-avatar-with-name">
+<ng-container *ngIf="leaderBoard else skeletonTemplate">
+    <div *ngIf="leaderBoard" class="tui-container tui-container_adaptive">
+        <div class="top-x-islands tui-space_bottom-8">
+            <tui-island *ngFor="let element of leaderBoard | tuiFilter: filterInTopX: rankTopX; let index = index"
+                        [style.marginTop]="(index) + 'rem'" [style.order]="(index % 2 * -index)"
+                        class="top-x-island"
+                        textAlign="center">
+                <div [style.backgroundColor]="avatar.bgColor" class="top-x-background"></div>
+                <figure class="tui-island__figure">
                     <tui-avatar
+                        #avatar
                         [autoColor]="true"
                         [rounded]="true"
                         [text]="element.name || 'Anonymous User'"
-                        class="tui-space_right-2"
-                        size="s"
+                        class="top-x-avatar"
+                        size="l"
                     ></tui-avatar>
+                </figure>
+                <p class="tui-island__paragraph tui-text_h3 tui-space_bottom-2">{{ getGetOrdinal(element.rank) }}</p>
+                <h3 class="tui-island__title">
                     {{ element.name || 'Anonymous User' }}
-                </div>
-            </td>
-            <td *tuiCell="'token'" tuiTd>
-                {{ element.token || 'No Tokens' }}
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
+                </h3>
+                <p class="tui-island__paragraph">
+                    {{ element.token ? (element.token + ' Tokens') : 'No Tokens' }}
+                </p>
+            </tui-island>
+        </div>
+        <table [columns]="displayedColumns" class="table" tuiTable>
+            <thead tuiThead>
+            <tr tuiThGroup>
+                <th *tuiHead="'rank'" tuiTh>Rank</th>
+                <th *tuiHead="'name'" tuiTh>Name</th>
+                <th *tuiHead="'token'" tuiTh>Tokens</th>
+            </tr>
+            </thead>
+            <tbody [data]="leaderBoard | tuiFilter: filterOutTopX: rankTopX" tuiTbody>
+            <tr *tuiRow="let element of leaderBoard" tuiTr>
+                <td *tuiCell="'rank'" tuiTd>
+                    {{ getGetOrdinal(element.rank) }}
+                </td>
+                <td *tuiCell="'name'" tuiTd>
+                    <div class="table-avatar-with-name">
+                        <tui-avatar
+                            [autoColor]="true"
+                            [rounded]="true"
+                            [text]="element.name || 'Anonymous User'"
+                            class="tui-space_right-2"
+                            size="s"
+                        ></tui-avatar>
+                        {{ element.name || 'Anonymous User' }}
+                    </div>
+                </td>
+                <td *tuiCell="'token'" tuiTd>
+                    {{ element.token || 'No Tokens' }}
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</ng-container>
+<ng-template #skeletonTemplate>
+    <div class="tui-container tui-container_adaptive">
+        <div class="top-x-islands tui-space_bottom-8">
+            <tui-island
+                        [style.marginTop]="1 + 'rem'" [style.order]="(1 % 2 * -1)"
+                        class="top-x-island"
+                        textAlign="center">
+                <div [style.backgroundColor]="avatar.bgColor" class="top-x-background tui-skeleton"></div>
+                <figure class="tui-island__figure tui-skeleton">
+                    <tui-avatar
+                        #avatar
+                        [autoColor]="true"
+                        [rounded]="true"
+                        [text]="'Anonymous User'"
+                        class="top-x-avatar tui-skeleton"
+                        size="l"
+                    ></tui-avatar>
+                </figure>
+                <p class="tui-island__paragraph tui-text_h3 tui-space_bottom-2 tui-skeleton">1st</p>
+                <h3 class="tui-island__title tui-skeleton">
+                    Anonymous User
+                </h3>
+                <p class="tui-island__paragraph tui-skeleton">
+                    No Tokens
+                </p>
+            </tui-island >
+            <tui-island
+                [style.marginTop]="2 + 'rem'" [style.order]="(2 % 2 * -2)"
+                class="top-x-island"
+                textAlign="center">
+                <div [style.backgroundColor]="avatar.bgColor" class="top-x-background tui-skeleton"></div>
+                <figure class="tui-island__figure tui-skeleton">
+                    <tui-avatar
+                        #avatar
+                        [autoColor]="true"
+                        [rounded]="true"
+                        [text]="'Anonymous User'"
+                        class="top-x-avatar tui-skeleton"
+                        size="l"
+                    ></tui-avatar>
+                </figure>
+                <p class="tui-island__paragraph tui-text_h3 tui-space_bottom-2 tui-skeleton">2nd</p>
+                <h3 class="tui-island__title tui-skeleton">
+                    Anonymous User
+                </h3>
+                <p class="tui-island__paragraph tui-skeleton">
+                    No Tokens
+                </p>
+            </tui-island >
+            <tui-island
+                [style.marginTop]="3 + 'rem'" [style.order]="(3 % 2 * -3)"
+                class="top-x-island"
+                textAlign="center">
+                <div [style.backgroundColor]="avatar.bgColor" class="top-x-background tui-skeleton"></div>
+                <figure class="tui-island__figure tui-skeleton">
+                    <tui-avatar
+                        #avatar
+                        [autoColor]="true"
+                        [rounded]="true"
+                        [text]="'Anonymous User'"
+                        class="top-x-avatar tui-skeleton"
+                        size="l"
+                    ></tui-avatar>
+                </figure>
+                <p class="tui-island__paragraph tui-text_h3 tui-space_bottom-2 tui-skeleton">3rd</p>
+                <h3 class="tui-island__title tui-skeleton">
+                    Anonymous User
+                </h3>
+                <p class="tui-island__paragraph tui-skeleton">
+                    No Tokens
+                </p>
+            </tui-island >
+        </div>
+        <table [columns]="displayedColumns" class="table" tuiTable>
+            <thead tuiThead>
+            <tr tuiThGroup>
+                <th *tuiHead="'rank'" tuiTh>Rank</th>
+                <th *tuiHead="'name'" tuiTh>Name</th>
+                <th *tuiHead="'token'" tuiTh>Tokens</th>
+            </tr>
+            </thead>
+            <tbody tuiTbody>
+            <tr tuiTr>
+                <td class="tui-skeleton" *tuiCell="'rank'" tuiTd>
+                    1st
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'name'" tuiTd>
+                    <div class="table-avatar-with-name">
+                        <tui-avatar
+                            [autoColor]="true"
+                            [rounded]="true"
+                            [text]="'Anonymous User'"
+                            class="tui-space_right-2"
+                            size="s"
+                        ></tui-avatar>
+                        Anonymous User
+                    </div>
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'token'" tuiTd>
+                    No Tokens
+                </td>
+            </tr>
+            <tr tuiTr>
+                <td class="tui-skeleton" *tuiCell="'rank'" tuiTd>
+                    1st
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'name'" tuiTd>
+                    <div class="table-avatar-with-name">
+                        <tui-avatar
+                            [autoColor]="true"
+                            [rounded]="true"
+                            [text]="'Anonymous User'"
+                            class="tui-space_right-2"
+                            size="s"
+                        ></tui-avatar>
+                        Anonymous User
+                    </div>
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'token'" tuiTd>
+                    No Tokens
+                </td>
+            </tr>
+            <tr tuiTr>
+                <td class="tui-skeleton" *tuiCell="'rank'" tuiTd>
+                    1st
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'name'" tuiTd>
+                    <div class="table-avatar-with-name">
+                        <tui-avatar
+                            [autoColor]="true"
+                            [rounded]="true"
+                            [text]="'Anonymous User'"
+                            class="tui-space_right-2"
+                            size="s"
+                        ></tui-avatar>
+                        Anonymous User
+                    </div>
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'token'" tuiTd>
+                    No Tokens
+                </td>
+            </tr>
+            <tr tuiTr>
+                <td class="tui-skeleton" *tuiCell="'rank'" tuiTd>
+                    1st
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'name'" tuiTd>
+                    <div class="table-avatar-with-name">
+                        <tui-avatar
+                            [autoColor]="true"
+                            [rounded]="true"
+                            [text]="'Anonymous User'"
+                            class="tui-space_right-2"
+                            size="s"
+                        ></tui-avatar>
+                        Anonymous User
+                    </div>
+                </td>
+                <td class="tui-skeleton"  *tuiCell="'token'" tuiTd>
+                    No Tokens
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</ng-template>

--- a/src/app/course/leader-board/leader-board.component.ts
+++ b/src/app/course/leader-board/leader-board.component.ts
@@ -1,5 +1,7 @@
-import {Component, Input, OnInit} from '@angular/core'
+import {Component, OnInit} from '@angular/core'
 import {LeaderboardElement} from "@app/_models"
+import {CourseService} from "@app/course/_services/course.service"
+import {ActivatedRoute} from "@angular/router"
 
 @Component({
     selector: 'app-leader-board',
@@ -7,15 +9,26 @@ import {LeaderboardElement} from "@app/_models"
     styleUrls: ['./leader-board.component.scss']
 })
 export class LeaderBoardComponent implements OnInit {
-    @Input() leaderBoard: LeaderboardElement[]
-    @Input() rankTopX: number
+    leaderBoard: LeaderboardElement[]
+    rankTopX: number
+    courseId: number
     displayedColumns: string[] = ['rank', 'name', 'token']
 
     readonly filterOutTopX = (element: LeaderboardElement, x: number): boolean => element.rank > x
     readonly filterInTopX = (element: LeaderboardElement, x: number): boolean => element.rank <= x
 
+    constructor(
+        private courseService: CourseService,
+        private route: ActivatedRoute
+    ) {
+        this.courseId = this.route.snapshot.parent.params.courseId
+    }
+
     ngOnInit(): void {
-        this.leaderBoard = this.getRankedLeaderboard(this.leaderBoard)
+        this.rankTopX = 3
+        this.courseService.getCourse(this.courseId).subscribe(course => {
+            this.leaderBoard = this.getRankedLeaderboard(course?.leader_board)
+        })
     }
 
     /**


### PR DESCRIPTION
## Description

Changed the course leaderboard and stats tile to just link to the course leaderboard. Also changed the leaderboard to load the course using course service and created a skeleton template for while the course is being fetched.

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [x] Every file touched has tests that cover all the funcitonality with green coverage
- [x] Documentation is updated (if applicable).

## Issue

https://github.com/COSC-447-Directed-Stuides/canvas-gamification-ui-COSOC447-directed-studies/issues/35

## Tests

Added test to leaderboard component to make sure it is fetching and ranking the leaderboard

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/83678885/208997483-423c003f-9ea0-4b1c-af53-82d0692043a1.png)

![image](https://user-images.githubusercontent.com/83678885/208997505-3ba1df54-607c-4704-80ca-5d6236a7f6a6.png)

![image](https://user-images.githubusercontent.com/83678885/208997529-f6d281a8-9cf9-4a25-a513-fe55c346f066.png)



